### PR TITLE
fix robot name from UsedRobot to BetterRobot

### DIFF
--- a/docs/en/python/oop.rst
+++ b/docs/en/python/oop.rst
@@ -84,7 +84,7 @@ Try the following:
             self.turn_left()
             self.turn_left()
 
-    reeborg = UsedRobot()
+    reeborg = BetterRobot()
     reeborg.turn_right()
 
 So far, so good ... but not much of an improvement.  We can do better.


### PR DESCRIPTION
While running python code, I had a complaint from Reeborg.
I think that it is necessary to align python code; from UsedRobot to BetterRobot

