### PR TITLE
Adding keyboard shortcuts to open/save code

### DIFF
--- a/reeborg.html
+++ b/reeborg.html
@@ -76,13 +76,11 @@
   document.addEventListener("keydown", function(e) {
   if (e.keyCode == 83 && (navigator.platform.match("Mac") ? e.metaKey : e.ctrlKey)) {
     e.preventDefault();
-    // alert("Saving now...")
     saveTextAsFile();
   }
 
   if (e.keyCode == 79 && (navigator.platform.match("Mac") ? e.metaKey : e.ctrlKey)) {
     e.preventDefault();
-    // alert("Saving now...")
     load_file(editor);
   }
   

--- a/reeborg.html
+++ b/reeborg.html
@@ -34,6 +34,61 @@
   <!-- load after codemirror.css -->
   <title>Reeborg's World</title>
 
+  <!-- intercepting keyboard save shortcut, ideas from 
+    - https://stackoverflow.com/questions/4446987/overriding-controls-save-functionality-in-browser 
+    - https://stackoverflow.com/questions/1085801/get-selected-value-in-dropdown-list-using-javascript#1085810
+  -->
+  <script type="text/javascript">
+    function saveTextAsFile() {
+      var blob;
+      event.preventDefault();
+      var selectedWorld = document.getElementById("select-world");
+      var filenameToSave = selectedWorld.options[selectedWorld.selectedIndex].text;
+      var editor_filename = document.getElementById("editor-filename");
+      if (RUR.state.programming_language == "python") {
+          blob = new Blob([editor.getValue()], {
+              type: "text/python;charset=utf-8"
+          });
+          saveAs(blob, filenameToSave + ".py", true);
+      } else {
+          blob = new Blob([editor.getValue()], {
+              type: "text/javascript;charset=utf-8"
+          });
+          saveAs(blob, filenameToSave + ".js", true);
+      }
+    }
+
+    function load_file (obj) {
+      // remove_fileInput_listener();
+      $("#fileInput").click();
+      var fileInput = document.getElementById('fileInput');
+      fileInput.addEventListener('change', function(e) {
+          var file = fileInput.files[0];
+          var reader = new FileReader();
+          reader.onload = function(e) {
+              obj.setValue(reader.result);
+              fileInput.value = '';
+          };
+          reader.readAsText(file);
+      });
+   }
+
+  document.addEventListener("keydown", function(e) {
+  if (e.keyCode == 83 && (navigator.platform.match("Mac") ? e.metaKey : e.ctrlKey)) {
+    e.preventDefault();
+    // alert("Saving now...")
+    saveTextAsFile();
+  }
+
+  if (e.keyCode == 79 && (navigator.platform.match("Mac") ? e.metaKey : e.ctrlKey)) {
+    e.preventDefault();
+    // alert("Saving now...")
+    load_file(editor);
+  }
+  
+
+}, false);</script>
+  
 </head>
 <body>
   <header class="blue-gradient green-border">


### PR DESCRIPTION
This might is not the most efficient way to do this, I'm sure, but I started using Reeborg with my students yesterday, and **by far** the largest problem was showing them how to save and open their code. As a partial solution to that problem, I've overridden the default keyboard commands for open/save, and tied them to importing/saving the code textarea.

Note that I've set the file to save as the name of the currently selected world, rather than pop open dialogue, since this provides a logical naming scheme for the file.